### PR TITLE
feat(test.sh) new migrations support features

### DIFF
--- a/scripts/diff_migrations
+++ b/scripts/diff_migrations
@@ -21,11 +21,13 @@ local function read_migrations(filename)
   for line in fd:lines() do
     local class, list = line:match("^([^:]*): (.*)$")
     local migs = {}
-    for mig in list:gmatch("[^, ]+") do
-      table.insert(migs, mig)
-      migs[mig] = true
+    if class and list then
+      for mig in list:gmatch("[^, ]+") do
+        table.insert(migs, mig)
+        migs[mig] = true
+      end
+      migrations[class] = migs
     end
-    migrations[class] = migs
   end
   fd:close()
   return migrations

--- a/semver.sh
+++ b/semver.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env sh
+
+function semverParseInto() {
+    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+    #MAJOR
+    eval $2=`echo $1 | sed -e "s#$RE#\1#"`
+    #MINOR
+    eval $3=`echo $1 | sed -e "s#$RE#\2#"`
+    #MINOR
+    eval $4=`echo $1 | sed -e "s#$RE#\3#"`
+    #SPECIAL
+    eval $5=`echo $1 | sed -e "s#$RE#\4#"`
+}
+
+function semverEQ() {
+    local MAJOR_A=0
+    local MINOR_A=0
+    local PATCH_A=0
+    local SPECIAL_A=0
+
+    local MAJOR_B=0
+    local MINOR_B=0
+    local PATCH_B=0
+    local SPECIAL_B=0
+
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+
+    if [ $MAJOR_A -ne $MAJOR_B ]; then
+        return 1
+    fi
+
+    if [ $MINOR_A -ne $MINOR_B ]; then
+        return 1
+    fi
+
+    if [ $PATCH_A -ne $PATCH_B ]; then
+        return 1
+    fi
+
+    if [[ "_$SPECIAL_A" != "_$SPECIAL_B" ]]; then
+        return 1
+    fi
+
+
+    return 0
+
+}
+
+function semverLT() {
+    local MAJOR_A=0
+    local MINOR_A=0
+    local PATCH_A=0
+    local SPECIAL_A=0
+
+    local MAJOR_B=0
+    local MINOR_B=0
+    local PATCH_B=0
+    local SPECIAL_B=0
+
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+
+    if [ $MAJOR_A -lt $MAJOR_B ]; then
+        return 0
+    fi
+
+    if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -lt $MINOR_B ]]; then
+        return 0
+    fi
+    
+    if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -le $MINOR_B && $PATCH_A -lt $PATCH_B ]]; then
+        return 0
+    fi
+
+    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+        return 1
+    fi
+    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  != "_" ]] ; then
+        return 1
+    fi
+    if [[ "_$SPECIAL_A"  != "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+        return 0
+    fi
+
+    if [[ "_$SPECIAL_A" < "_$SPECIAL_B" ]]; then
+        return 0
+    fi
+
+    return 1
+
+}
+
+function semverGT() {
+    semverEQ $1 $2
+    local EQ=$?
+
+    semverLT $1 $2
+    local LT=$?
+
+    if [ $EQ -ne 0 ] && [ $LT -ne 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if [ "___semver.sh" == "___`basename $0`" ]; then
+
+MAJOR=0
+MINOR=0
+PATCH=0
+SPECIAL=""
+
+semverParseInto $1 MAJOR MINOR PATCH SPECIAL
+echo "$1 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+
+semverParseInto $2 MAJOR MINOR PATCH SPECIAL
+echo "$2 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+
+semverEQ $1 $2
+echo "$1 == $2 -> $?."
+
+semverLT $1 $2
+echo "$1 < $2 -> $?."
+
+semverGT $1 $2
+echo "$1 > $2 -> $?."
+
+fi

--- a/upgrade_paths/0.14.1_0.15.0/after/001-dummy.json
+++ b/upgrade_paths/0.14.1_0.15.0/after/001-dummy.json
@@ -1,0 +1,10 @@
+[
+  [ "dummy request after, first node",
+    [ "admin", "GET", "/services/" ],
+    [ 200 ]
+  ],
+  [ "dummy request after, second node",
+    [ "admin_2", "GET", "/services/" ],
+    [ 200 ]
+  ]
+]

--- a/upgrade_paths/0.14.1_0.15.0/before/001-dummy.json
+++ b/upgrade_paths/0.14.1_0.15.0/before/001-dummy.json
@@ -1,0 +1,10 @@
+[
+  [ "dummy request before, first node",
+    [ "admin", "GET", "/services/" ],
+    [ 200 ]
+  ],
+  [ "dummy request before, second node",
+    [ "admin_2", "GET", "/services/" ],
+    [ 200 ]
+  ]
+]

--- a/upgrade_paths/0.14.1_0.15.0/migrating/001-dummy.json
+++ b/upgrade_paths/0.14.1_0.15.0/migrating/001-dummy.json
@@ -1,0 +1,10 @@
+[
+  [ "dummy request migrating, first node",
+    [ "admin", "GET", "/services/" ],
+    [ 200 ]
+  ],
+  [ "dummy request migrating, second node",
+    [ "admin_2", "GET", "/services/" ],
+    [ 200 ]
+  ]
+]

--- a/util/json_commands.lua
+++ b/util/json_commands.lua
@@ -335,13 +335,11 @@ end
 
 ------
 
-function _M.execute(admin_url, proxy_url, admin_ssl_url, proxy_ssl_url, file_path)
-  local http_clients = {
-    admin = test_helpers.new_http_client("admin", admin_url, "http"),
-    proxy = test_helpers.new_http_client("proxy", proxy_url, "http"),
-    admin_ssl = test_helpers.new_http_client("admin", admin_ssl_url, "https"),
-    proxy_ssl = test_helpers.new_http_client("proxy", proxy_ssl_url, "https"),
-  }
+function _M.execute(clients, file_path)
+  local http_clients = {}
+  for name, url in pairs(clients) do
+    http_clients[name] = test_helpers.new_http_client(name, url)
+  end
 
   return execute_commands(read_json_file(file_path), http_clients, file_path)
 end

--- a/util/json_commands_runner.lua
+++ b/util/json_commands_runner.lua
@@ -2,16 +2,48 @@ local json_commands = require "util.json_commands"
 
 local function show_usage()
   io.stderr:write(
-    "Usage: resty json_commands_runner.lua admin:port proxy:port admin_ssl:port proxy_ssl:port filepath\n")
+    "\nUsage: resty json_commands_runner.lua filepath" ..
+    "\nThe command expects the following environment variables to be set: " ..
+    "\n* $ADMIN_LISTEN" ..
+    "\n* $PROXY_LISTEN" ..
+    "\n* $ADMIN_LISTEN_SSL" ..
+    "\n* $PROXY_LISTEN_SSL" ..
+    "\n* $ADMIN_LISTEN_2" ..
+    "\n* $PROXY_LISTEN_2" ..
+    "\n* $ADMIN_LISTEN_SSL_2" ..
+    "\n* $PROXY_LISTEN_SSL_2" ..
+    "\nIf any of these is missing, it will just exit with this error message."
+  )
   os.exit(1)
 end
 
 ------
 
-if not arg[1] or not arg[2] or not arg[3] or not arg[4] or not arg[5] then
+local admin       = os.getenv("ADMIN_LISTEN")
+local proxy       = os.getenv("PROXY_LISTEN")
+local admin_ssl   = os.getenv("ADMIN_LISTEN_SSL")
+local proxy_ssl   = os.getenv("PROXY_LISTEN_SSL")
+local admin_2     = os.getenv("ADMIN_LISTEN_2")
+local proxy_2     = os.getenv("PROXY_LISTEN_2")
+local admin_ssl_2 = os.getenv("ADMIN_LISTEN_SSL_2")
+local proxy_ssl_2 = os.getenv("PROXY_LISTEN_SSL_2")
+
+if not arg[1]
+  or not admin or not admin_ssl or not proxy or not proxy_ssl
+  or not admin_2 or not admin_ssl_2 or not proxy_2 or not proxy_ssl_2 then
   show_usage()
 end
 
-json_commands.execute(arg[1], arg[2], arg[3], arg[4], arg[5])
+json_commands.execute({
+    admin = "http://" .. admin,
+    proxy = "http://" .. proxy,
+    admin_ssl = "https://" .. admin_ssl,
+    proxy_ssl = "https://" .. proxy_ssl,
+    admin_2 = "http://" .. admin_2,
+    proxy_2 = "http://" .. proxy_2,
+    admin_ssl_2 = "https://" .. admin_ssl_2,
+    proxy_ssl_2 = "https://" .. proxy_ssl_2,
+  },
+  arg[1])
 
 os.exit(0)

--- a/util/test_helpers.lua
+++ b/util/test_helpers.lua
@@ -5,20 +5,26 @@ local cjson = require "cjson"
 local _M = {}
 local http = require "resty.http"
 
-local function extract_host_port(url)
+local function extract_scheme_host_port(url)
   local parsed = assert(surl.parse(url))
+
+  local scheme = parsed.scheme
+  if not scheme then
+    error("missing scheme in url: " .. url)
+  end
 
   local host = parsed.host
   if not host then
-    error("mising host in url")
+    error("mising host in url: " .. url)
   end
 
   local port = tonumber(parsed.port)
   if not port then
-    error("missing or invalid port in url")
+    error("missing or invalid port in url: " .. url)
   end
 
-  return host, port
+
+  return scheme, host, port
 end
 
 
@@ -116,12 +122,12 @@ local _httpc_mt = {
 }
 
 
-function _M.new_http_client(name, url, scheme)
+function _M.new_http_client(name, url)
   if not url then
     error("missing " .. name .. " url", 2)
   end
 
-  local host, port = extract_host_port(url)
+  local scheme, host, port = extract_scheme_host_port(url)
 
   return setmetatable({
     host = host,


### PR DESCRIPTION
This commit does 4 things:
* Detects when a version of kong needs new migrations (version number is > 0.14.1 or branch name == next)
* Runs `kong migrations bootstrap` && `kong migrations fininsh` on the kong versions that support them
* Adds a new test suite section called `migrating`, for running the tests after migrations up and before migrations finish
* Starts two kong instances instead of one in order to perform
  multi-node tests. To use the second node, use `admin_2` or `proxy_2`
  instead of `admin` or `proxy` in the json commands.

I also added some dummy commands (they just GET `/services` from both
nodes). In order to run them execute this:

./test.sh -b kong:0.14.1 -t kong:next upgrade_paths/0.14.1_0.15.0

Problems:

`next` is identified as "having new migrations" while 0.14.1 is "old migrations". This means when attempting to use `next`, kong will complain because "the database is not boostrapped". I have made test.sh detect this condition (base is old-migs, target is new-migs) and it runs `kong migrations boostrap` after installing target.

The problem is that the current `kong migrations bootstrap` erases the database (I think). There doesn't seem to be an "actual path" between 0.14.x and 0.15.x at the moment.

Possible fixes:
* Make `kong upgrade boostrap` detect that "it is upgrading from an older Kong" and not erase the database, but convert the old migrations.
* Make `test.sh` fix the problem by doing clever SQL/CQL queries.