### PR TITLE
tests(1.1.0_1.2.0) upgrade tests for 1.1.0 to 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,30 @@ env:
     - TEST_FROM=1.0.0
       TEST_TO=1.1.0
       DATABASE=cassandra
+    - TEST_FROM=0.14.1
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=postgres
+    - TEST_FROM=1.0.0
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=postgres
+    - TEST_FROM=1.1.0
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=postgres
+    - TEST_FROM=0.14.1
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=cassandra
+    - TEST_FROM=1.0.0
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=cassandra
+    - TEST_FROM=1.1.0
+      TEST_TO=next
+      UPATH_TO=1.2.0
+      DATABASE=cassandra
 
 script:
-  - ./test.sh -b $TEST_REPO:$TEST_FROM -t $TEST_REPO:$TEST_TO -d $DATABASE "$TRAVIS_BUILD_DIR/upgrade_paths/${TEST_FROM}_${TEST_TO}/"
+  - ./test.sh -b $TEST_REPO:$TEST_FROM -t $TEST_REPO:$TEST_TO -d $DATABASE "$TRAVIS_BUILD_DIR/upgrade_paths/${TEST_FROM}_${UPATH_TO-$TEST_TO}/"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ Tests are written in a JSON-based DSL, described below:
     } ]
   ],
 
+  [ "run a Cassandra CQL statement, get the results back",
+    [ "cql", "SELECT * FROM services" ],
+    [ 2, {
+      "type": "ROWS",
+      "1": {
+        "name": "service_1",
+        "id": "c75e22b7-1e77-41b1-9d8b-e1704d4d08ae",
+        ...
+      },
+      "2": {
+        "name": "service_2",
+        "id": "3ac42fe7-898e-4ed3-ac13-3dde3fa329d0",
+        ...
+      }
+    ]
+    } ]
+  ],
+
+
 ]
 ```
 
@@ -297,6 +316,32 @@ Example:
 * `<body>` is an array with zero or more results. If there are results, they will be encoded as
   json objects. Their format depends on the SQL statements introduced.
 
+
+### CQL
+
+```
+[ "cql", <cql> ]
+```
+
+* `<cql>` is a string with one cql statement.
+
+Example:
+
+```
+[ "cql", "SELECT * FROM routes" ]
+```
+
+### CQL responses
+
+```
+[ <number-of-rows>, <body> ]
+```
+
+* `<number-of-rows>` is the number of rows returned by the body. Literally `#body`.
+* `<body>` is a table returned by `lua-cassandra`. It usually has a `type` value. Expressions
+  returning rows (such as a Select will have a `ROWS` type). `body[1]`
+  would be the first row, `body[2]` the second one, and so on. Other types of requests
+  could have other formats. See the lua-cassandra docs for examples.
 
 ### String interpolation and regular expressions
 

--- a/test.sh
+++ b/test.sh
@@ -380,6 +380,7 @@ run_json_commands() {
         export CASSANDRA_PORT=9042
         export CASSANDRA_KEYSPACE=kong
         resty -e "package.path = package.path .. ';' .. '/mig_tool/?.lua'" \
+              --shdict="cassandra 1m"                                      \
               /mig_tool/util/json_commands_runner.lua /mig_tool/$l_filepath
 EOF
       ) >&5 || failed_test "$name json commands failed with: $?"

--- a/upgrade_paths/0.14.1_1.2.0/after/001-plugin.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/001-plugin.json
@@ -1,0 +1,90 @@
+[
+  [ "jwt2_service",
+    [ "admin_2", "POST", "/services", {
+      "name": "jwt2_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "jwt2_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "jwt2_service_plugin",
+    [ "admin_2", "POST", "/plugins", {
+      "name": "jwt",
+      "service": { "id": "#{jwt2_service.id}" },
+      "config": {
+        "claims_to_verify": [ "exp" ]
+      }
+    } ],
+    [ 201, {
+      "name": "jwt",
+      "service": { "id":  "#{jwt2_service.id}" },
+      "config": {
+        "claims_to_verify": [
+          "exp"
+        ],
+        "anonymous": null,
+        "cookie_names": {},
+        "key_claim_name": "iss",
+        "maximum_expiration": 0,
+        "run_on_preflight": true,
+        "secret_is_base64": false,
+        "uri_param_names": [
+          "jwt"
+        ]
+      },
+      "enabled": true
+    } ]
+  ],
+  [ "jwt2_route",
+    [ "admin_2", "POST", "/services/#{jwt2_service.id}/routes", {
+      "hosts": [ "jwt2_api.test" ]
+    } ],
+    [ 201, {
+      "hosts": [ "jwt2_api.test" ]
+    } ]
+  ],
+  [ "test jwt2 blocks calls to jwt2_api without a token",
+    [ "proxy_2", "GET", "/", "", { "Host": "jwt2_api.test" } ],
+    [ 401, {
+      "message": "Unauthorized"
+    } ]
+  ],
+  [ "green cluster: list plugins for jwt2_service",
+    [ "admin_2", "GET", "/services/#{jwt2_service.id}/plugins", "", {} ],
+    [ 200, {
+        "data": [
+          { "name": "jwt",
+            "%created_at": "\\d+",
+            "service": { "id": "#{jwt2_service.id}" },
+            "config": {
+              "claims_to_verify": [
+                "exp"
+              ],
+              "anonymous": null,
+              "cookie_names": {},
+              "key_claim_name": "iss",
+              "maximum_expiration": 0,
+              "run_on_preflight": true,
+              "secret_is_base64": false,
+              "uri_param_names": [
+                "jwt"
+              ]
+            }
+          }
+        ],
+        "next": null
+      }
+    ]
+  ],
+
+  [ "green cluster, after: test jwt still blocks calls to jwt_api without a token",
+    [ "proxy_2", "GET", "/", "", { "Host": "jwt_api.test" } ],
+    [ 401, {
+      "message": "Unauthorized"
+    } ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/002-tags.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/002-tags.json
@@ -1,0 +1,61 @@
+[
+  [ "test_service_after",
+    [ "admin_2", "PATCH", "/services/#{test_service.id}", {
+      "tags": [ "tag1", "tag2" ]
+    } ],
+    [ 200, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https",
+      "tags": [ "tag1", "tag2" ]
+    } ]
+  ],
+  [ "test_route_after",
+    [ "admin_2", "PATCH", "/routes/#{test_route.id}", {
+      "tags": [ "tag1" ]
+    } ],
+    [ 200, {
+      "tags": [ "tag1" ]
+    } ]
+  ],
+  [ "test_service check after",
+    [ "admin_2", "GET", "/services/#{test_service.id}" ],
+    [ 200, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https",
+      "tags": [ "tag1", "tag2" ]
+    } ]
+  ],
+  [ "filter by tag after migraqtion",
+    [ "admin_2", "GET", "/services?tags=tag2" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https",
+        "tags": [ "tag1", "tag2" ]
+      } ]
+    } ]
+  ],
+  [ "new /tags endpoint shows tagged services",
+    [ "admin_2", "GET", "/tags/tag2" ],
+    [ 200, {
+        "data": [ {
+          "entity_name": "services",
+          "tag": "tag2"
+        }
+      ]
+    } ]
+  ],
+  [ "test proxy works after migration",
+    [ "proxy_2", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "%Via": "kong/1\\.1\\.2(?:rc\\d)?" }
+    ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/004-oauth2.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/004-oauth2.json
@@ -1,0 +1,13 @@
+[
+  [ "oauth2_credentials still has redirect_uris",
+    [ "admin_2", "GET", "/consumers/#{oauth2_consumer.id}/oauth2/#{oauth2_credentials.id}" ],
+    [ 200, {
+      "name": "testapp",
+      "client_id": "clientid123",
+      "client_secret": "secret123",
+      "redirect_uris": [ "http://google.com/kong" ],
+      "consumer": { "id": "#{oauth2_consumer.id}" }
+    } ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/after/005-oauth2.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/005-oauth2.postgresql.json
@@ -1,0 +1,7 @@
+[
+  [ "oauth2_credentials does not have a redirect_uri column any more",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'redirect_uri' and table_name = 'oauth2_credentials'" ],
+    [ 1, [] ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/after/006-acl.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/006-acl.json
@@ -1,0 +1,7 @@
+[
+  [ "acls still work",
+    [ "admin_2", "GET", "/consumers/acl_consumer/acls/admin" ],
+    [ 200, { "group": "admin" } ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/after/008-rate-limiting.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/008-rate-limiting.postgresql.json
@@ -1,0 +1,10 @@
+[
+  [ "increment_rate_limits_api function is removed",
+    [ "psql", "select * from pg_proc where proname = 'increment_rate_limits_api'" ],
+    [ 1, [] ]
+  ],
+  [ "several increment_rate_limits function are removed",
+    [ "psql", "select * from pg_proc where proname = 'increment_rate_limits'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/009-response-ratelimiting.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/009-response-ratelimiting.postgresql.json
@@ -1,0 +1,10 @@
+[
+  [ "increment_response_rate_limits_api function is removed",
+    [ "psql", "select * from pg_proc where proname = 'increment_response_rate_limits_api'" ],
+    [ 1, [] ]
+  ],
+  [ "several increment_response_rate_limits function are removed",
+    [ "psql", "select * from pg_proc where proname = 'increment_response_rate_limits'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/010-plugin-with-apis.cassandra.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/010-plugin-with-apis.cassandra.json
@@ -1,0 +1,115 @@
+[
+  [ "some_service",
+    [ "admin_2", "POST", "/services", {
+      "url": "http://mockbin.org/request"
+    } ],
+    [ 201, {
+      "%id": "[0-9a-fA-F\\-]+",
+      "%created_at": "\\d+",
+      "%updated_at": "\\d+",
+      "connect_timeout": 60000,
+      "host": "mockbin.org",
+      "name": null,
+      "path": "/request",
+      "port": 80,
+      "protocol": "http",
+      "read_timeout": 60000,
+      "retries": 5,
+      "write_timeout": 60000
+    } ]
+  ],
+  [ "some_route",
+    [ "admin_2", "POST", "/routes", {
+      "hosts": [ "some.test" ],
+      "paths": [ "/request" ],
+      "service": {
+        "id": "#{some_service.id}"
+      }
+    } ],
+    [ 201, {
+      "%id": "[0-9a-fA-F\\-]+",
+      "%created_at": "\\d+",
+      "%updated_at": "\\d+",
+      "hosts": [
+        "some.test"
+      ],
+      "methods": null,
+      "paths": [ "/request" ],
+      "preserve_host": false,
+      "regex_priority": 0,
+      "protocols": [
+        "http",
+        "https"
+      ],
+      "service": {
+        "id": "#{some_service.id}"
+      },
+      "strip_path": true
+     } ]
+  ],
+  [ "request is not blocked by plugin on apis",
+    [ "proxy_2", "GET", "/request", "", { "Host": "some.test" } ],
+    [ 200, {
+      "headers": {
+        "host": "mockbin.org"
+      },
+      "method": "GET",
+      "url": "http://some.test/request"
+    } ]
+  ],
+
+  [ "listing all plugins does not return the ones created with apis",
+    [ "admin_2", "GET", "/plugins?size=5", "", {} ],
+    [ 200, {
+      "data": [
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true }
+      ],
+      "next": null
+    } ]
+  ],
+
+  [ "inserting a new key-auth global plugin",
+    [ "admin_2", "POST", "/plugins", {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ],
+    [ 201, {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ]
+  ],
+
+  [ "inserting another new key-auth global plugin",
+    [ "admin_2", "POST", "/plugins", {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ],
+    [ 409, {
+      "name": "unique constraint violation"
+    } ]
+  ],
+
+  [ "listing all plugins does not return the ones created with apis (2)",
+    [ "admin_2", "GET", "/plugins?size=6", "", {} ],
+    [ 200, {
+      "data": [
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true }
+      ],
+      "next": null
+    } ]
+  ]
+
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/010-plugin-with-apis.postgres.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/010-plugin-with-apis.postgres.json
@@ -1,0 +1,115 @@
+[
+  [ "some_service",
+    [ "admin_2", "POST", "/services", {
+      "url": "http://mockbin.org/request"
+    } ],
+    [ 201, {
+      "%id": "[0-9a-fA-F\\-]+",
+      "%created_at": "\\d+",
+      "%updated_at": "\\d+",
+      "connect_timeout": 60000,
+      "host": "mockbin.org",
+      "name": null,
+      "path": "/request",
+      "port": 80,
+      "protocol": "http",
+      "read_timeout": 60000,
+      "retries": 5,
+      "write_timeout": 60000
+    } ]
+  ],
+  [ "some_route",
+    [ "admin_2", "POST", "/routes", {
+      "hosts": [ "some.test" ],
+      "paths": [ "/request" ],
+      "service": {
+        "id": "#{some_service.id}"
+      }
+    } ],
+    [ 201, {
+      "%id": "[0-9a-fA-F\\-]+",
+      "%created_at": "\\d+",
+      "%updated_at": "\\d+",
+      "hosts": [
+        "some.test"
+      ],
+      "methods": null,
+      "paths": [ "/request" ],
+      "preserve_host": false,
+      "regex_priority": 0,
+      "protocols": [
+        "http",
+        "https"
+      ],
+      "service": {
+        "id": "#{some_service.id}"
+      },
+      "strip_path": true
+     } ]
+  ],
+  [ "request is not blocked by plugin on apis",
+    [ "proxy_2", "GET", "/request", "", { "Host": "some.test" } ],
+    [ 200, {
+      "headers": {
+        "host": "mockbin.org"
+      },
+      "method": "GET",
+      "url": "http://some.test/request"
+    } ]
+  ],
+
+  [ "listing all plugins does not return the ones created with apis",
+    [ "admin_2", "GET", "/plugins?size=4", "", {} ],
+    [ 200, {
+      "data": [
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true }
+      ],
+      "next": null
+    } ]
+  ],
+
+  [ "inserting a new key-auth global plugin",
+    [ "admin_2", "POST", "/plugins", {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ],
+    [ 201, {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ]
+  ],
+
+  [ "inserting another new key-auth global plugin",
+    [ "admin_2", "POST", "/plugins", {
+      "name": "key-auth",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ],
+    [ 409, {
+      "name": "unique constraint violation"
+    } ]
+  ],
+
+  [ "listing all plugins does not return the ones created with apis (2)",
+    [ "admin_2", "GET", "/plugins?size=5", "", {} ],
+    [ 200, {
+      "data": [
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true },
+        { "enabled": true }
+      ],
+      "next": null
+    } ]
+  ]
+
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/011-plugin-with-routes.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/011-plugin-with-routes.json
@@ -1,0 +1,23 @@
+[
+  [ "test key-auth with routes still works in green cluster: blocks requests without api key",
+    [ "proxy_2", "GET", "/request", "", { "Host": "key_auth_rs_service.com" } ],
+    [ 401,
+      { "message": "No API key found in request" },
+      { "WWW-Authenticate": "Key realm=\"kong\"" }
+    ]
+  ],
+
+  [ "test key-auth with routes still works in green cluster: does not block with api key",
+    [ "proxy_2", "GET", "/request", "", {
+      "Host": "key_auth_rs_service.com",
+      "routekey": "key_auth_rs_service_secret"
+    } ],
+    [ 200, {
+      "headers": {
+        "routekey": "key_auth_rs_service_secret"
+      },
+      "method": "GET"
+    } ]
+  ]
+
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/021-tags.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/021-tags.postgresql.json
@@ -1,0 +1,114 @@
+[
+  [ "tags table is created after migrations to 1.1.0",
+    [ "psql", "select * from information_schema.tables where table_name = 'tags'" ],
+    [ 1, [ { "table_name": "tags" } ] ]
+  ],
+  [ "tags_entity_name_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'tags_entity_name_idx'" ],
+    [ 1, [ { "tablename": "tags" } ] ]
+  ],
+  [ "tags_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'tags_tags_idx'" ],
+    [ 1, [ { "tablename": "tags" } ] ]
+  ],
+  [ "sync_tags function is created",
+    [ "psql", "select count(*) from pg_proc where proname = 'sync_tags'" ],
+    [ 1, [ { "count": 1 } ] ]
+  ],
+  [ "services.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'services'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "services_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'services_tags_idx'" ],
+    [ 1, [ { "tablename": "services" } ] ]
+  ],
+  [ "services_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'services_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "routes.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'routes'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "routes_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'routes_tags_idx'" ],
+    [ 1, [ { "tablename": "routes" } ] ]
+  ],
+  [ "routes_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'routes_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "certificates.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'certificates'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "certificates_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'certificates_tags_idx'" ],
+    [ 1, [ { "tablename": "certificates" } ] ]
+  ],
+  [ "certificates_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'certificates_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "snis.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'snis'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "snis_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'snis_tags_idx'" ],
+    [ 1, [ { "tablename": "snis" } ] ]
+  ],
+  [ "snis_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'snis_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "consumers.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'consumers'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "consumers_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'consumers_tags_idx'" ],
+    [ 1, [ { "tablename": "consumers" } ] ]
+  ],
+  [ "consumers_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'consumers_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "plugins.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'plugins'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "plugins_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'plugins_tags_idx'" ],
+    [ 1, [ { "tablename": "plugins" } ] ]
+  ],
+  [ "plugins_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'plugins_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "upstreams.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'upstreams'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "upstreams_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'upstreams_tags_idx'" ],
+    [ 1, [ { "tablename": "upstreams" } ] ]
+  ],
+  [ "upstreams_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'upstreams_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "targets.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'targets'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "targets_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'targets_tags_idx'" ],
+    [ 1, [ { "tablename": "targets" } ] ]
+  ],
+  [ "targets_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'targets_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/022-misc.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/022-misc.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "upsert_ttl function is removed",
+    [ "psql", "select count(*) from pg_proc where proname = 'upsert_ttl'" ],
+    [ 1, [ { "count": 0 } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/023-plugins.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/023-plugins.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "plugins.protocols field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'protocols' and table_name = 'plugins'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/024-cluster_mutex.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/024-cluster_mutex.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "cluster_events_expire_at_idx index is created after migrations to 1.2.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'cluster_events_expire_at_idx'" ],
+    [ 1, [ { "tablename": "cluster_events" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/after/025-routes.cassandra.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/025-routes.cassandra.json
@@ -1,0 +1,8 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'routes' and column_name = 'https_redirect_status_code'" ],
+    [ 1, [ { "type": "int" } ] ]
+  ]
+]
+
+

--- a/upgrade_paths/0.14.1_1.2.0/after/025-routes.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/after/025-routes.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'https_redirect_status_code' and table_name = 'routes'" ],
+    [ 1, [ { "data_type": "integer" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/001-plugin.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/001-plugin.json
@@ -1,0 +1,56 @@
+[
+  [ "jwt_service",
+    [ "admin", "POST", "/services", {
+      "name": "jwt_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "jwt_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "jwt_service_plugin",
+    [ "admin", "POST", "/plugins", {
+      "name": "jwt",
+      "service_id": "#{jwt_service.id}",
+      "config": {
+        "claims_to_verify": "exp"
+      }
+    } ],
+    [ 201, {
+      "name": "jwt",
+      "service_id": "#{jwt_service.id}",
+      "config": {
+        "claims_to_verify": [
+          "exp"
+        ],
+        "anonymous": "",
+        "cookie_names": {},
+        "key_claim_name": "iss",
+        "maximum_expiration": 0,
+        "run_on_preflight": true,
+        "secret_is_base64": false,
+        "uri_param_names": [
+          "jwt"
+        ]
+      },
+      "enabled": true
+    } ]
+  ],
+  [ "jwt_route",
+    [ "admin", "POST", "/services/#{jwt_service.id}/routes", {
+      "hosts": [ "jwt_api.test" ]
+    } ],
+    [ 201, {
+      "hosts": [ "jwt_api.test" ]
+    } ]
+  ],
+  [ "test jwt blocks calls to jwt_api without a token",
+    [ "proxy", "GET", "/", "", { "Host": "jwt_api.test" } ],
+    [ 401, {
+      "message": "Unauthorized"
+    } ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/002-routes-name.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/002-routes-name.json
@@ -1,0 +1,25 @@
+[
+  [ "service for route without name",
+    [ "admin", "POST", "/services", {
+      "name": "route_name_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "route_name_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "route with name throws error",
+    [ "admin", "POST", "/services/route_name_service/routes", {
+      "hosts": [ "route-with-name.test" ],
+      "name": "route-name"
+    } ],
+    [ 400, {
+      "fields": {
+        "name": "unknown field"
+      }
+    } ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/003-index-renaming.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/003-index-renaming.postgresql.json
@@ -1,0 +1,61 @@
+[
+  [ "targets have no index called targets_upstream_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'targets' and indexname = 'targets_upstream_id_idx'" ],
+    [ 1, [] ]
+  ],
+
+  [ "upstreams index on name is named upstreams_name_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'upstreams' and indexname = 'upstreams_name_idx'" ],
+    [ 1, [ { "tablename": "upstreams", "indexname": "upstreams_name_idx" } ] ]
+  ],
+
+  [ "consumers index on custom_id is named custom_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'custom_id_idx'" ],
+    [ 1, [ { "tablename": "consumers", "indexname": "custom_id_idx" } ] ]
+  ],
+
+  [ "consumers index on username is named consumers_username_key",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'consumers_username_key'" ],
+    [ 1, [ { "tablename": "consumers", "indexname": "consumers_username_key" } ] ]
+  ],
+
+  [ "certificates id index is called ssl_certificates_pkey",
+    [ "psql", "select * from pg_indexes where tablename = 'certificates' and indexname = 'ssl_certificates_pkey'" ],
+    [ 1, [ { "tablename": "certificates", "indexname": "ssl_certificates_pkey" } ] ]
+  ],
+
+  [ "cluster events at index is called idx_cluster_events_at",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'idx_cluster_events_at'" ],
+    [ 1, [ { "tablename": "cluster_events", "indexname": "idx_cluster_events_at" } ] ]
+  ],
+
+  [ "cluster events channel index is called idx_cluster_events_channel",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'idx_cluster_events_channel'" ],
+    [ 1, [ { "tablename": "cluster_events", "indexname": "idx_cluster_events_channel" } ] ]
+  ],
+
+  [ "routes index on service_id is called routes_fkey_service",
+    [ "psql", "select * from pg_indexes where tablename = 'routes' and indexname = 'routes_fkey_service'" ],
+    [ 1, [ { "tablename": "routes", "indexname": "routes_fkey_service" } ] ]
+  ],
+
+  [ "snis have no index called snis_fkey_certificate",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_fkey_certificate'" ],
+    [ 1, [] ]
+  ],
+  [ "snis have no index called snis_certificate_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_certificate_id_idx'" ],
+    [ 1, [] ]
+  ],
+
+
+  [ "snis are indexed by name with snis_name_unique",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_name_unique'" ],
+    [ 1, [ { "tablename": "snis", "indexname": "snis_name_unique" } ] ]
+  ],
+
+  [ "plugins are indexed by consumer_id with plugins_consumer_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'plugins' and indexname = 'plugins_consumer_idx'" ],
+    [ 1, [ { "tablename": "plugins", "indexname": "plugins_consumer_idx" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/004-oauth2.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/004-oauth2.json
@@ -1,0 +1,60 @@
+[
+  [ "oauth2_service",
+    [ "admin", "POST", "/services", {
+      "name": "oauth2_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "oauth2_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+
+  [ "oauth2_consumer",
+    [ "admin", "POST", "/consumers", { "username": "oauth2_consumer" } ],
+    [ 201, { "username": "oauth2_consumer" } ]
+  ],
+
+  [ "oauth2_plugin",
+    [ "admin", "POST", "/plugins", {
+      "name": "oauth2",
+      "service_id": "#{oauth2_service.id}",
+      "config": {
+        "scopes": [ "email", "profile", "user.email" ],
+        "enable_authorization_code": true,
+        "mandatory_scope": true,
+        "provision_key": "provision123"
+      }
+    } ],
+    [ 201, {
+      "name": "oauth2",
+      "service_id": "#{oauth2_service.id}",
+      "config": {
+        "scopes": [ "email", "profile", "user.email" ],
+        "enable_authorization_code": true,
+        "mandatory_scope": true,
+        "provision_key": "provision123"
+      }
+    } ]
+  ],
+
+  [ "oauth2_credentials",
+    [ "admin", "POST", "/consumers/#{oauth2_consumer.id}/oauth2", {
+      "name": "testapp",
+      "client_id": "clientid123",
+      "client_secret": "secret123",
+      "redirect_uri": "http://google.com/kong",
+      "consumer_id": "#{oauth2_consumer.id}"
+    } ],
+    [ 201, {
+      "name": "testapp",
+      "client_id": "clientid123",
+      "client_secret": "secret123",
+      "redirect_uri": [ "http://google.com/kong" ],
+      "consumer_id": "#{oauth2_consumer.id}"
+    } ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/before/006-acl.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/006-acl.json
@@ -1,0 +1,25 @@
+[
+  [ "acl_services",
+    [ "admin", "POST", "/services", {
+      "name": "acl_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "acl_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+
+  [ "acl_consumer",
+    [ "admin", "POST", "/consumers", { "username": "acl_consumer" } ],
+    [ 201, { "username": "acl_consumer" } ]
+  ],
+
+  [ "acl",
+    [ "admin", "POST", "/consumers/acl_consumer/acls", { "group": "admin" } ],
+    [ 201, { "group": "admin" } ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/before/010-plugin-with-apis.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/010-plugin-with-apis.json
@@ -1,0 +1,65 @@
+[
+  [ "key_auth_api",
+    [ "admin", "POST", "/apis", {
+      "name": "key_auth_api",
+      "hosts": "key_auth_api.com",
+      "upstream_url": "https://mockbin.org"
+    } ],
+    [ 201, {
+      "name": "key_auth_api",
+      "hosts": [ "key_auth_api.com" ],
+      "upstream_url": "https://mockbin.org"
+    } ]
+  ],
+
+  [ "key-auth plugin",
+    [ "admin", "POST", "/plugins", {
+      "name": "key-auth",
+      "api_id": "#{key_auth_api.id}",
+      "config": {
+        "key_names": [ "apis-apikey" ]
+      }
+    } ],
+    [ 201, {
+      "name": "key-auth",
+      "api_id": "#{key_auth_api.id}"
+    } ]
+  ],
+
+  [ "key_auth_consumer",
+    [ "admin", "POST", "/consumers", { "username": "key_auth_consumer" } ],
+    [ 201, { "username": "key_auth_consumer" } ]
+  ],
+
+  [ "key_auth credentials",
+    [ "admin", "POST", "/consumers/#{key_auth_consumer.id}/key-auth", {
+      "key": "key_auth_api_secret"
+    } ],
+    [ 201, {
+      "key": "key_auth_api_secret",
+      "consumer_id": "#{key_auth_consumer.id}"
+    } ]
+  ],
+
+  [ "test key-auth blocks requests without API key",
+    [ "proxy", "GET", "/request", "", { "Host": "key_auth_api.com" } ],
+    [ 401,
+      { "message": "No API key found in request" },
+      { "WWW-Authenticate": "Key realm=\"kong\"" }
+    ]
+  ],
+
+  [ "test key-auth does not block with API key",
+    [ "proxy", "GET", "/request", "", {
+      "Host": "key_auth_api.com",
+      "apis-apikey": "key_auth_api_secret"
+    } ],
+    [ 200, {
+      "headers": {
+        "apis-apikey": "key_auth_api_secret"
+      },
+      "method": "GET"
+    } ]
+  ]
+
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/011-plugin-with-routes.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/011-plugin-with-routes.json
@@ -1,0 +1,74 @@
+[
+  [ "key_auth_rs_service",
+    [ "admin", "POST", "/services", {
+      "name": "key_auth_rs_service",
+      "url": "https://mockbin.org"
+    } ],
+    [ 201, {
+      "name": "key_auth_rs_service"
+    } ]
+  ],
+
+  [ "key_auth_rs_route",
+    [ "admin", "POST", "/routes", {
+      "hosts": ["key_auth_rs_service.com"],
+      "service": {
+        "id": "#{key_auth_rs_service.id}"
+      }
+    } ],
+    [ 201, {
+      "hosts": [ "key_auth_rs_service.com" ]
+    } ]
+  ],
+
+  [ "key-auth plugin on service",
+    [ "admin", "POST", "/plugins", {
+      "name": "key-auth",
+      "service_id": "#{key_auth_rs_service.id}",
+      "config": {
+        "key_names": [ "routekey" ]
+      }
+    } ],
+    [ 201, {
+      "name": "key-auth",
+      "service_id": "#{key_auth_rs_service.id}"
+    } ]
+  ],
+
+  [ "key_auth_rs_consumer",
+    [ "admin", "POST", "/consumers", { "username": "key_auth_rs_consumer" } ],
+    [ 201, { "username": "key_auth_rs_consumer" } ]
+  ],
+
+  [ "key_auth with routes: credentials",
+    [ "admin", "POST", "/consumers/#{key_auth_rs_consumer.id}/key-auth", {
+      "key": "key_auth_rs_service_secret"
+    } ],
+    [ 201, {
+      "key": "key_auth_rs_service_secret",
+      "consumer_id": "#{key_auth_rs_consumer.id}"
+    } ]
+  ],
+
+  [ "test key-auth with routes: blocks requests without api key",
+    [ "proxy", "GET", "/request", "", { "Host": "key_auth_rs_service.com" } ],
+    [ 401,
+      { "message": "No API key found in request" },
+      { "WWW-Authenticate": "Key realm=\"kong\"" }
+    ]
+  ],
+
+  [ "test key-auth with routes: does not block with api key",
+    [ "proxy", "GET", "/request", "", {
+      "Host": "key_auth_rs_service.com",
+      "routekey": "key_auth_rs_service_secret"
+    } ],
+    [ 200, {
+      "headers": {
+        "routekey": "key_auth_rs_service_secret"
+      },
+      "method": "GET"
+    } ]
+  ]
+
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/020-basic-proxying.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/020-basic-proxying.json
@@ -1,0 +1,39 @@
+[
+  [ "test_service",
+    [ "admin", "POST", "/services", {
+      "name": "test_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "test_route",
+    [ "admin", "POST", "/services/#{test_service.id}/routes", {
+      "hosts": [ "test_service.example.com" ]
+    } ],
+    [ 201, {
+      "hosts": [ "test_service.example.com" ]
+    } ]
+  ],
+  [ "test_service check",
+    [ "admin", "GET", "/services/#{test_service.id}" ],
+    [ 200, {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https"
+      }
+    ]
+  ],
+  [ "test proxy works",
+    [ "proxy", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "Via": "kong/0.14.1" }
+    ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/before/999-remove-apis.json
+++ b/upgrade_paths/0.14.1_1.2.0/before/999-remove-apis.json
@@ -1,0 +1,7 @@
+[
+  [ "delete key_auth_api",
+    [ "admin", "DELETE", "/apis/#{key_auth_api.id}", {
+    } ],
+    [ 204, {} ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/001-plugin.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/001-plugin.json
@@ -1,0 +1,56 @@
+[
+  [ "blue cluster: test jwt still blocks calls to jwt_api without a token",
+    [ "proxy", "GET", "/", "", { "Host": "jwt_api.test" } ],
+    [ 401, {
+      "message": "Unauthorized"
+    } ]
+  ],
+  [ "green cluster: list routes",
+    [ "admin_2", "GET", "/routes", "", {} ],
+    [ 200, {
+        "data": [
+          {
+          }
+        ],
+        "next": null
+      }
+    ]
+  ],
+  [ "green cluster: get jwt_service",
+    [ "admin_2", "GET", "/services/#{jwt_service.id}", "", {} ],
+    [ 200, {
+      "%created_at": "\\d+",
+      "%updated_at": "\\d+",
+      "connect_timeout": 60000,
+      "host": "httpbin.org",
+      "name": "jwt_service",
+      "path": "/anything",
+      "port": 443,
+      "protocol": "https",
+      "read_timeout": 60000,
+      "retries": 5,
+      "write_timeout": 60000,
+      "id": "#{jwt_service.id}"
+      }
+    ]
+  ],
+  [ "green cluster: list plugins for jwt_service, with new run_on field",
+    [ "admin_2", "GET", "/services/#{jwt_service.id}/plugins", "", {} ],
+    [ 200, {
+        "data": [
+          {
+            "run_on": "first"
+          }
+        ],
+        "next": null
+      }
+    ]
+  ],
+
+  [ "green cluster: test jwt still blocks calls to jwt_api without a token",
+    [ "proxy_2", "GET", "/", "", { "Host": "jwt_api.test" } ],
+    [ 401, {
+      "message": "Unauthorized"
+    } ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/002-routes-name.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/002-routes-name.json
@@ -1,0 +1,12 @@
+[
+  [ "route with name is accepted",
+    [ "admin_2", "POST", "/services/route_name_service/routes", {
+      "hosts": [ "route-with-name.test" ],
+      "name": "route-name"
+    } ],
+    [ 201, {
+      "hosts": [ "route-with-name.test" ],
+      "name": "route-name"
+    } ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/003-index-renaming.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/003-index-renaming.postgresql.json
@@ -1,0 +1,92 @@
+[
+  [ "targets now *do* have an index called targets_upstream_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'targets' and indexname = 'targets_upstream_id_idx'" ],
+    [ 1, [ { "tablename": "targets", "indexname": "targets_upstream_id_idx" } ] ]
+  ],
+
+
+  [ "upstreams index on name upstreams_name_idx was dropped",
+    [ "psql", "select * from pg_indexes where tablename = 'upstreams' and indexname = 'upstreams_name_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "upstreams still have an UNIQUE index on name called upstreams_name_key",
+    [ "psql", "select * from pg_indexes where tablename = 'upstreams' and indexname = 'upstreams_name_key'" ],
+    [ 1, [ { "tablename": "upstreams", "indexname": "upstreams_name_key" } ] ]
+  ],
+
+
+  [ "consumers index on username is not consumers_username_key any more",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'consumers_username_key'" ],
+    [ 1, [] ]
+  ],
+  [ "consumers index on username is now called consumers_username_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'consumers_username_idx'" ],
+    [ 1, [ { "tablename": "consumers", "indexname": "consumers_username_idx" } ] ]
+  ],
+
+
+  [ "consumers index on custom_id is not custom_id_idx any more",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'custom_id_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "consumers still have a UNIQUE index on custom_id called consumers_custom_id_key",
+    [ "psql", "select * from pg_indexes where tablename = 'consumers' and indexname = 'consumers_custom_id_key'" ],
+    [ 1, [ { "tablename": "consumers", "indexname": "consumers_custom_id_key" } ] ]
+  ],
+
+
+  [ "certificates id index ssl_certificates_pkey no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'certificates' and indexname = 'ssl_certificates_pkey'" ],
+    [ 1, [] ]
+  ],
+  [ "certificates id index was renamed to certificates_pkey",
+    [ "psql", "select * from pg_indexes where tablename = 'certificates' and indexname = 'certificates_pkey'" ],
+    [ 1, [ { "tablename": "certificates", "indexname": "certificates_pkey" } ] ]
+  ],
+
+
+  [ "cluster events at index idx_cluster_events_at no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'idx_cluster_events_at'" ],
+    [ 1, [] ]
+  ],
+  [ "cluster events at index was renamed to cluster_events_at_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'cluster_events_at_idx'" ],
+    [ 1, [ { "tablename": "cluster_events", "indexname": "cluster_events_at_idx" } ] ]
+  ],
+
+
+  [ "cluster events channel index is no longer idx_cluster_events_channel",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'idx_cluster_events_channel'" ],
+    [ 1, [] ]
+  ],
+  [ "cluster events channel index was renamed to cluster_events_channel_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'cluster_events' and indexname = 'cluster_events_channel_idx'" ],
+    [ 1, [ { "tablename": "cluster_events", "indexname": "cluster_events_channel_idx" } ] ]
+  ],
+
+
+  [ "routes index on service_id is no longer routes_fkey_service",
+    [ "psql", "select * from pg_indexes where tablename = 'routes' and indexname = 'routes_fkey_service'" ],
+    [ 1, [] ]
+  ],
+  [ "routes index on service_id was renamed to routes_service_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'routes' and indexname = 'routes_service_id_idx'" ],
+    [ 1, [ { "tablename": "routes", "indexname": "routes_service_id_idx" } ] ]
+  ],
+
+
+  [ "snis are now indexed on certificate_id, and their cert is named snis_certificate_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_certificate_id_idx'" ],
+    [ 1, [ { "tablename": "snis", "indexname": "snis_certificate_id_idx" } ] ]
+  ],
+
+
+  [ "snis index by name is no longer snis_name_unique",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_name_unique'" ],
+    [ 1, [] ]
+  ],
+  [ "snis index by name is now snis_name_key",
+    [ "psql", "select * from pg_indexes where tablename = 'snis' and indexname = 'snis_name_key'" ],
+    [ 1, [ { "tablename": "snis", "indexname": "snis_name_key" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/005-oauth2.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/005-oauth2.postgresql.json
@@ -1,0 +1,55 @@
+[
+  [ "oauth2_authorization_codes has a ttl field",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'ttl' and table_name = 'oauth2_authorization_codes'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "oauth2_tokens has a ttl field",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'ttl' and table_name = 'oauth2_tokens'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "oauth2_authorization_codes created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'oauth2_authorization_codes'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "oauth2_tokens created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'oauth2_tokens'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "oauth2_credentials created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'oauth2_credentials'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "oauth2_credentials index by consumer is no longer oauth2_credentials_consumer_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_credentials' and indexname = 'oauth2_credentials_consumer_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "oauth2_credentials index by consumer is now oauth2_credentials_consumer_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_credentials' and indexname = 'oauth2_credentials_consumer_id_idx'" ],
+    [ 1, [ { "tablename": "oauth2_credentials", "indexname": "oauth2_credentials_consumer_id_idx" } ] ]
+  ],
+
+  [ "oauth2_authorization_codes index by user_id is no longer oauth2_authorization_userid_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_authorization_codes' and indexname = 'oauth2_authorization_userid_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "oauth2_authorization_codes index by name is now oauth2_authorization_codes_authenticated_user_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_authorization_codes' and indexname = 'oauth2_authorization_codes_authenticated_userid_idx'" ],
+    [ 1, [ { "tablename": "oauth2_authorization_codes", "indexname": "oauth2_authorization_codes_authenticated_userid_idx" } ] ]
+  ],
+
+  [ "oauth2_tokens index by authenticated userid is no longer oauth2_token_userid_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_tokens' and indexname = 'oauth2_token_userid_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "oauth2_tokens index by authenticated userid is now oauth2_tokens_authenticated_userid_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'oauth2_tokens' and indexname = 'oauth2_tokens_authenticated_userid_idx'" ],
+    [ 1, [ { "tablename": "oauth2_tokens", "indexname": "oauth2_tokens_authenticated_userid_idx" } ] ]
+  ]
+
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/migrating/006-acl.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/006-acl.postgresql.json
@@ -1,0 +1,20 @@
+[
+  [ "acls has a cache_key field",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'cache_key' and table_name = 'acls'" ],
+    [ 1, [ { "data_type": "text" } ] ]
+  ],
+
+  [ "acls created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'acls'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "acls index by consumer is no longer acls_consumer_id",
+    [ "psql", "select * from pg_indexes where tablename = 'acls' and indexname = 'acls_consumer_id'" ],
+    [ 1, [] ]
+  ],
+  [ "acls index by consumer is now acls_consumer_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'acls' and indexname = 'acls_consumer_id_idx'" ],
+    [ 1, [ { "tablename": "acls", "indexname": "acls_consumer_id_idx" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/007-hmacauth.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/007-hmacauth.postgresql.json
@@ -1,0 +1,20 @@
+[
+  [ "hmacauth_credentials created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'hmacauth_credentials'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "hmacauth_credentials index by consumer is no longer hmacauth_credentials_consumer_id",
+    [ "psql", "select * from pg_indexes where tablename = 'hmacauth_credentials' and indexname = 'hmacauth_credentials_consumer_id'" ],
+    [ 1, [] ]
+  ],
+  [ "hmacauth_credentials index by consumer is now hmacauth_credentials_consumer_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'hmacauth_credentials' and indexname = 'hmacauth_credentials_consumer_id_idx'" ],
+    [ 1, [ { "tablename": "hmacauth_credentials", "indexname": "hmacauth_credentials_consumer_id_idx" } ] ]
+  ],
+
+  [ "hmacauth_credentials index hmacauth_credentials_username no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'hmacauth_credentials' and indexname = 'hmacauth_credentials_username'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/008-rate-limiting.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/008-rate-limiting.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "ratelimiting_metrics period_date has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'period_date' and table_name = 'ratelimiting_metrics'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/009-response-ratelimiting.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/009-response-ratelimiting.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "response_ratelimiting_metrics period_date has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'period_date' and table_name = 'response_ratelimiting_metrics'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/010-keyauth.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/010-keyauth.postgresql.json
@@ -1,0 +1,20 @@
+[
+  [ "keyauth_credentials created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'keyauth_credentials'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "keyauth_credentials index by consumer is no longer keyauth_consumer_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'keyauth_credentials' and indexname = 'keyauth_consumer_idx'" ],
+    [ 1, [] ]
+  ],
+  [ "keyauth_credentials index by consumer is now keyauth_consumer_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'keyauth_credentials' and indexname = 'keyauth_credentials_consumer_id_idx'" ],
+    [ 1, [ { "tablename": "keyauth_credentials", "indexname": "keyauth_credentials_consumer_id_idx" } ] ]
+  ],
+
+  [ "keyauth_credentials index keyauth_key_idx no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'keyauth_credentials' and indexname = 'keyauth_key_idx'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/011-basicauth.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/011-basicauth.postgresql.json
@@ -1,0 +1,11 @@
+[
+  [ "basicauth_credentials created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'basicauth_credentials'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "basicauth_credentials index basicauth_username_idx no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'basicauth_credentials' and indexname = 'basicauth_username_idx'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/011-plugin-with-routes.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/011-plugin-with-routes.json
@@ -1,0 +1,44 @@
+[
+  [ "test key-auth with routes still works in blue cluster: blocks requests without api key",
+    [ "proxy", "GET", "/request", "", { "Host": "key_auth_rs_service.com" } ],
+    [ 401,
+      { "message": "No API key found in request" },
+      { "WWW-Authenticate": "Key realm=\"kong\"" }
+    ]
+  ],
+
+  [ "test key-auth with routes still works in blue cluster: does not block with api key",
+    [ "proxy", "GET", "/request", "", {
+      "Host": "key_auth_rs_service.com",
+      "routekey": "key_auth_rs_service_secret"
+    } ],
+    [ 200, {
+      "headers": {
+        "routekey": "key_auth_rs_service_secret"
+      },
+      "method": "GET"
+    } ]
+  ],
+
+  [ "test key-auth with routes works in green cluster: blocks requests without api key",
+    [ "proxy_2", "GET", "/request", "", { "Host": "key_auth_rs_service.com" } ],
+    [ 401,
+      { "message": "No API key found in request" },
+      { "WWW-Authenticate": "Key realm=\"kong\"" }
+    ]
+  ],
+
+  [ "test key-auth with routes works in green cluster: does not block with api key",
+    [ "proxy_2", "GET", "/request", "", {
+      "Host": "key_auth_rs_service.com",
+      "routekey": "key_auth_rs_service_secret"
+    } ],
+    [ 200, {
+      "headers": {
+        "routekey": "key_auth_rs_service_secret"
+      },
+      "method": "GET"
+    } ]
+  ]
+]
+

--- a/upgrade_paths/0.14.1_1.2.0/migrating/012-jwt.postgresql.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/012-jwt.postgresql.json
@@ -1,0 +1,29 @@
+[
+  [ "jwt_secrets created_at has a time zone now",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'created_at' and table_name = 'jwt_secrets'" ],
+    [ 1, [ { "data_type": "timestamp with time zone" } ] ]
+  ],
+
+  [ "jwt_secrets index jwt_secrets_consumer_id no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'jwt_secrets' and indexname = 'jwt_secrets_consumer_id'" ],
+    [ 1, [] ]
+  ],
+  [ "jwt_secrets index for consumer is now called jwt_secrets_consumer_id_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'jwt_secrets' and indexname = 'jwt_secrets_consumer_id_idx'" ],
+    [ 1, [] ]
+  ],
+
+  [ "jwt_secrets index jwt_secrets_secret no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'jwt_secrets' and indexname = 'jwt_secrets_secret'" ],
+    [ 1, [] ]
+  ],
+  [ "jwt_secrets index for secret is now called jwt_secrets_secret_idx",
+    [ "psql", "select * from pg_indexes where tablename = 'jwt_secrets' and indexname = 'jwt_secrets_secret_idx'" ],
+    [ 1, [] ]
+  ],
+
+  [ "jwt_secrets index jwt_secrets_key no longer exists",
+    [ "psql", "select * from pg_indexes where tablename = 'jwt_secrets' and indexname = 'jwt_secrets_key'" ],
+    [ 1, [] ]
+  ]
+]

--- a/upgrade_paths/0.14.1_1.2.0/migrating/020-tags.json
+++ b/upgrade_paths/0.14.1_1.2.0/migrating/020-tags.json
@@ -1,0 +1,61 @@
+[
+  [ "test_service_migrating",
+    [ "admin_2", "PATCH", "/services/#{test_service.id}", {
+      "tags": [ "tag1", "tag2" ]
+    } ],
+    [ 200, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https",
+      "tags": [ "tag1", "tag2" ]
+    } ]
+  ],
+  [ "test_route_migrating",
+    [ "admin_2", "PATCH", "/routes/#{test_route.id}", {
+      "tags": [ "tag1" ]
+    } ],
+    [ 200, {
+      "tags": [ "tag1" ]
+    } ]
+  ],
+  [ "test_service check migrating",
+    [ "admin_2", "GET", "/services/#{test_service.id}" ],
+    [ 200, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https",
+      "tags": [ "tag1", "tag2" ]
+    } ]
+  ],
+  [ "filter by tag during migraqtion",
+    [ "admin_2", "GET", "/services?tags=tag2" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https",
+        "tags": [ "tag1", "tag2" ]
+      } ]
+    } ]
+  ],
+  [ "new /tags endpoint shows tagged services during migration",
+    [ "admin_2", "GET", "/tags/tag2" ],
+    [ 200, {
+        "data": [ {
+          "entity_name": "services",
+          "tag": "tag2"
+        }
+      ]
+    } ]
+  ],
+  [ "test proxy works during migration",
+    [ "proxy_2", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "%Via": "kong/1\\.1\\.2(?:rc\\d)?" }
+    ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/020-tags.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/020-tags.json
@@ -1,0 +1,63 @@
+[
+  [ "test_service_after",
+    [ "admin_2", "PATCH", "/services/#{test_service.id}", {
+      "tags": [ "tag1", "tag2" ]
+    } ],
+    [ 200, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https",
+      "tags": [ "tag1", "tag2" ]
+    } ]
+  ],
+  [ "test_route_after",
+    [ "admin_2", "PATCH", "/routes/#{test_route.id}", {
+      "tags": [ "tag1" ]
+    } ],
+    [ 200, {
+      "tags": [ "tag1" ]
+    } ]
+  ],
+  [ "test_service check after",
+    [ "admin_2", "GET", "/services" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https",
+        "tags": [ "tag1", "tag2" ]
+      } ]
+    } ]
+  ],
+  [ "filter by tag after migraqtion",
+    [ "admin_2", "GET", "/services?tags=tag2" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https",
+        "tags": [ "tag1", "tag2" ]
+      } ]
+    } ]
+  ],
+  [ "new /tags endpoint shows tagged services",
+    [ "admin_2", "GET", "/tags/tag2" ],
+    [ 200, {
+        "data": [ {
+          "entity_name": "services",
+          "tag": "tag2"
+        }
+      ]
+    } ]
+  ],
+  [ "test proxy works after migration",
+    [ "proxy_2", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "%Via": "kong/1\\.1\\.2(?:rc\\d)?" }
+    ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/021-tags.postgresql.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/021-tags.postgresql.json
@@ -1,0 +1,114 @@
+[
+  [ "tags table is created after migrations to 1.1.0",
+    [ "psql", "select * from information_schema.tables where table_name = 'tags'" ],
+    [ 1, [ { "table_name": "tags" } ] ]
+  ],
+  [ "tags_entity_name_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'tags_entity_name_idx'" ],
+    [ 1, [ { "tablename": "tags" } ] ]
+  ],
+  [ "tags_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'tags_tags_idx'" ],
+    [ 1, [ { "tablename": "tags" } ] ]
+  ],
+  [ "sync_tags function is created",
+    [ "psql", "select count(*) from pg_proc where proname = 'sync_tags'" ],
+    [ 1, [ { "count": 1 } ] ]
+  ],
+  [ "services.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'services'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "services_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'services_tags_idx'" ],
+    [ 1, [ { "tablename": "services" } ] ]
+  ],
+  [ "services_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'services_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "routes.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'routes'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "routes_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'routes_tags_idx'" ],
+    [ 1, [ { "tablename": "routes" } ] ]
+  ],
+  [ "routes_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'routes_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "certificates.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'certificates'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "certificates_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'certificates_tags_idx'" ],
+    [ 1, [ { "tablename": "certificates" } ] ]
+  ],
+  [ "certificates_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'certificates_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "snis.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'snis'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "snis_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'snis_tags_idx'" ],
+    [ 1, [ { "tablename": "snis" } ] ]
+  ],
+  [ "snis_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'snis_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "consumers.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'consumers'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "consumers_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'consumers_tags_idx'" ],
+    [ 1, [ { "tablename": "consumers" } ] ]
+  ],
+  [ "consumers_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'consumers_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "plugins.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'plugins'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "plugins_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'plugins_tags_idx'" ],
+    [ 1, [ { "tablename": "plugins" } ] ]
+  ],
+  [ "plugins_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'plugins_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "upstreams.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'upstreams'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "upstreams_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'upstreams_tags_idx'" ],
+    [ 1, [ { "tablename": "upstreams" } ] ]
+  ],
+  [ "upstreams_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'upstreams_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ],
+  [ "targets.tags field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'tags' and table_name = 'targets'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ],
+  [ "targets_tags_idx index is created after migrations to 1.1.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'targets_tags_idx'" ],
+    [ 1, [ { "tablename": "targets" } ] ]
+  ],
+  [ "targets_sync_tags_trigger trigger is (re)created (3 triggers: INSERT, DELETE, UPDATE)",
+    [ "psql", "select count(*) from information_schema.triggers where trigger_name = 'targets_sync_tags_trigger'" ],
+    [ 1, [ { "count": 3 } ] ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/022-misc.postgresql.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/022-misc.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "upsert_ttl function is removed",
+    [ "psql", "select count(*) from pg_proc where proname = 'upsert_ttl'" ],
+    [ 1, [ { "count": 0 } ] ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/023-plugins.postgresql.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/023-plugins.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "plugins.protocols field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'protocols' and table_name = 'plugins'" ],
+    [ 1, [ { "data_type": "ARRAY" } ] ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/024-cluster_mutex.postgresql.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/024-cluster_mutex.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "cluster_events_expire_at_idx index is created after migrations to 1.2.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'cluster_events_expire_at_idx'" ],
+    [ 1, [ { "tablename": "cluster_events" } ] ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/after/025-routes.cassandra.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/025-routes.cassandra.json
@@ -1,0 +1,8 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'routes' and column_name = 'https_redirect_status_code'" ],
+    [ 1, [ { "type": "int" } ] ]
+  ]
+]
+
+

--- a/upgrade_paths/1.0.0_1.2.0/after/025-routes.postgresql.json
+++ b/upgrade_paths/1.0.0_1.2.0/after/025-routes.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'https_redirect_status_code' and table_name = 'routes'" ],
+    [ 1, [ { "data_type": "integer" } ] ]
+  ]
+]

--- a/upgrade_paths/1.0.0_1.2.0/before/001-basic-proxying.json
+++ b/upgrade_paths/1.0.0_1.2.0/before/001-basic-proxying.json
@@ -1,0 +1,40 @@
+[
+  [ "test_service",
+    [ "admin", "POST", "/services", {
+      "name": "test_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "test_route",
+    [ "admin", "POST", "/services/#{test_service.id}/routes", {
+      "hosts": [ "test_service.example.com" ]
+    } ],
+    [ 201, {
+      "hosts": [ "test_service.example.com" ]
+    } ]
+  ],
+  [ "test_service check",
+    [ "admin", "GET", "/services" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https"
+      } ]
+    } ]
+  ],
+  [ "test proxy works",
+    [ "proxy", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "Via": "kong/1.0.0" }
+    ]
+  ]
+]

--- a/upgrade_paths/1.1.0_1.2.0/after/024-cluster_mutex.postgresql.json
+++ b/upgrade_paths/1.1.0_1.2.0/after/024-cluster_mutex.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "cluster_events_expire_at_idx index is created after migrations to 1.2.0",
+    [ "psql", "select tablename from pg_indexes where indexname = 'cluster_events_expire_at_idx'" ],
+    [ 1, [ { "tablename": "cluster_events" } ] ]
+  ]
+]

--- a/upgrade_paths/1.1.0_1.2.0/after/025-routes.cassandra.json
+++ b/upgrade_paths/1.1.0_1.2.0/after/025-routes.cassandra.json
@@ -1,0 +1,8 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'routes' and column_name = 'https_redirect_status_code'" ],
+    [ 1, [ { "type": "int" } ] ]
+  ]
+]
+
+

--- a/upgrade_paths/1.1.0_1.2.0/after/025-routes.postgresql.json
+++ b/upgrade_paths/1.1.0_1.2.0/after/025-routes.postgresql.json
@@ -1,0 +1,6 @@
+[
+  [ "routes.https_redirect_status_code field is added",
+    [ "psql", "select data_type from information_schema.columns where column_name = 'https_redirect_status_code' and table_name = 'routes'" ],
+    [ 1, [ { "data_type": "integer" } ] ]
+  ]
+]

--- a/upgrade_paths/1.1.0_1.2.0/before/001-basic-proxying.json
+++ b/upgrade_paths/1.1.0_1.2.0/before/001-basic-proxying.json
@@ -1,0 +1,40 @@
+[
+  [ "test_service",
+    [ "admin", "POST", "/services", {
+      "name": "test_service",
+      "url": "https://httpbin.org/anything"
+    } ],
+    [ 201, {
+      "name": "test_service",
+      "host": "httpbin.org",
+      "path": "/anything",
+      "protocol": "https"
+    } ]
+  ],
+  [ "test_route",
+    [ "admin", "POST", "/services/#{test_service.id}/routes", {
+      "hosts": [ "test_service.example.com" ]
+    } ],
+    [ 201, {
+      "hosts": [ "test_service.example.com" ]
+    } ]
+  ],
+  [ "test_service check",
+    [ "admin", "GET", "/services" ],
+    [ 200, {
+      "data": [ {
+        "name": "test_service",
+        "host": "httpbin.org",
+        "path": "/anything",
+        "protocol": "https"
+      } ]
+    } ]
+  ],
+  [ "test proxy works",
+    [ "proxy", "GET", "/", "", { "Host": "test_service.example.com" } ],
+    [ 200,
+      null,
+      { "Via": "kong/1.1.0" }
+    ]
+  ]
+]


### PR DESCRIPTION
### Summary

Adds upgrade-tests to Kong 1.2.0.

#### How to Test:

##### If there is no `1.2.0` tag

In that case we must use `kong:next` to test:

Postgres:
```
rm -rf cache; rm -rf tmp; ./test.sh -b 0.14.1 -t kong:next \
                                    upgrade_paths/0.14.1_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.0.0 -t kong:next \
                                    upgrade_paths/1.0.0_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.1.0 -t kong:next \
                                    upgrade_paths/1.1.0_1.2.0
```

Cassandra:
```
rm -rf cache; rm -rf tmp; ./test.sh -b 0.14.1 -t kong:next -d cassandra \
                                    upgrade_paths/0.14.1_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.0.0 -t kong:next -d cassandra \
                                    upgrade_paths/1.0.0_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.1.0 -t kong:next -d cassandra \
                                    upgrade_paths/1.1.0_1.2.0
```

##### If there's a `1.2.0` tag

Once we have a `1.2.0` tag we can use that instead of `kong:next`:

Postgres:
```
rm -rf cache; rm -rf tmp; ./test.sh -b 0.14.1 -t 1.2.0 \
                                    upgrade_paths/0.14.1_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.0.0 -t 1.2.0 \
                                    upgrade_paths/1.0.0_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.1.0 -t 1.2.0 \
                                    upgrade_paths/1.1.0_1.2.0
```

Cassandra:
```
rm -rf cache; rm -rf tmp; ./test.sh -b 0.14.1 -t 1.2.0 -d cassandra \
                                    upgrade_paths/0.14.1_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.0.0 -t 1.2.0 -d cassandra \
                                    upgrade_paths/1.0.0_1.2.0

rm -rf cache; rm -rf tmp; ./test.sh -b 1.1.0 -t 1.2.0 -d cassandra \
                                    upgrade_paths/1.1.0_1.2.0
```