### PR TITLE
fix(*) do not search for run_on in plugins for Cassandra databases

### DIFF
--- a/upgrade_paths/1.0.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.0.0_2.0.0/after/001-core.cassandra.json
@@ -1,13 +1,4 @@
 [
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {

--- a/upgrade_paths/1.1.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.1.0_2.0.0/after/001-core.cassandra.json
@@ -1,13 +1,4 @@
 [
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {

--- a/upgrade_paths/1.2.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.2.0_2.0.0/after/001-core.cassandra.json
@@ -1,13 +1,4 @@
 [
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {

--- a/upgrade_paths/1.3.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.3.0_2.0.0/after/001-core.cassandra.json
@@ -3,15 +3,6 @@
     [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'upstreams' and column_name = 'host_header'" ],
     [ 1, [ { "type": "text" } ] ]
   ],
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {

--- a/upgrade_paths/1.4.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.4.0_2.0.0/after/001-core.cassandra.json
@@ -1,13 +1,4 @@
 [
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {

--- a/upgrade_paths/1.5.0_2.0.0/after/001-core.cassandra.json
+++ b/upgrade_paths/1.5.0_2.0.0/after/001-core.cassandra.json
@@ -1,13 +1,4 @@
 [
-  [ "run_on column was dropped from plugins",
-    [ "cql", "SELECT type FROM system_schema.columns WHERE keyspace_name = 'kong' AND table_name = 'plugins' and column_name = 'run_on'" ],
-    [ 0, {
-      "meta": {
-        "has_more_pages": false
-      },
-      "type": "ROWS"
-    } ]
-  ],
   [ "cluster_ca table does not exist",
     [ "cql", "SELECT table_name FROM system_schema.tables WHERE keyspace_name = 'kong' AND table_name = 'cluster_ca'" ],
     [ 0, {


### PR DESCRIPTION
Column run_on is not being removed from plugins in Cassandra databases, so we should not test this.